### PR TITLE
AMD module definition fix for Issue #5

### DIFF
--- a/src/publisher.js
+++ b/src/publisher.js
@@ -6,7 +6,7 @@
 
 (function (name, definition){
   if (typeof define == 'function'){ // AMD
-    define(definition);
+    define(function(){ return definition()});
   } else if (typeof module != 'undefined' && module.exports) { // Node.js
     module.exports = definition();
   } else { // Browser


### PR DESCRIPTION
Changes the AMD `define` call to be detectable by the RequireJS optimization tool.

Fixes Issue #5
